### PR TITLE
支持格式化分令时

### DIFF
--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -2,6 +2,21 @@ import { INVALID_DATE_STRING, FORMAT_DEFAULT, REGEX_FORMAT } from '../constants'
 import { padZoneStr } from '../utils'
 import { _GlobalConfig } from '../config'
 
+/**
+ * 返回当前时间对应的分令。0-9分为子分，10-19分为寅分，以此类推。
+ * @param hour 当前小时数
+ * @param minute 当前分钟数
+ */
+const formatMinutes = (hour: number, minute: number): string => {
+  const isEven = hour % 2 == 0
+  const resolvedMinute = isEven ? minute + 60 : minute
+  // 一个时辰120分钟对应12份，每份10分钟
+  const minutesPerPortion = 120 / 12;
+  const index = Math.floor(resolvedMinute / minutesPerPortion);
+  const branchName = lunisolar.Branch.getNames()[index]
+  return branchName
+}
+
 export const format = (formatStr: string, lsr: lunisolar.Lunisolar): string => {
   if (lsr.toUTCString() === INVALID_DATE_STRING) return INVALID_DATE_STRING
   let str = formatStr || FORMAT_DEFAULT
@@ -85,6 +100,7 @@ export const format = (formatStr: string, lsr: lunisolar.Lunisolar): string => {
     cH: char8.hour.toString(),
     cHs: char8.hour.stem.toString(),
     cHb: char8.hour.branch.toString(),
+    cFb: formatMinutes(H, m),
     // 八字（数字形式）
     cYn: char8.year.value,
     cYsn: char8.year.stem.value,


### PR DESCRIPTION
支持格式化分令时。分令把一个时辰的120分钟分成12份，一份10分钟，每份用子丑寅卯对应。
这是我第一次创建PR，可能对于此项目的源码并没有理解通透，我现在是直接在格式化方法内处理的，但我觉得最理想的情况下其实应该是作为lunisolar类的属性可以直接访问，因为每个时间对象都有自己对应的分令。或者如果代码风格或者设计理念不符的话，你也可以直接修改，多谢